### PR TITLE
build: adds build workflow, updates license and readme

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,38 @@
 name: Publish to npm
 
 on:
-    release:
-        types: [created]
+  release:
+    types: [created]
 
 jobs:
-    publish:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-            - name: Set up Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '24.x'
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
 
-            - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
-              with:
-                  bun-version: latest
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
-            - name: Set up Go
-              uses: actions/setup-go@v5
-              with:
-                  go-version: '1.24.4'
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.4'
 
-            - name: Install dependencies
-              run: bun install
+      - name: Install dependencies
+        run: bun install
 
-            - name: Build plugin binaries
-              run: bun run build:plugin
+      - name: Build plugin binaries
+        run: bun run build:plugin
 
-            - name: Publish package to npm
-              run: npm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish package to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to npm
+
+on:
+    release:
+        types: [created]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24.x'
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: '1.24.4'
+
+            - name: Install dependencies
+              run: bun install
+
+            - name: Build plugin binaries
+              run: bun run build:plugin
+
+            - name: Publish package to npm
+              run: npm publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# bin
+bin/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+/*
+ * ----------------------------------------------------------------------------
+ * "THE BEER-WARE LICENSE" (Revision 42):
+ * <jacob@jacobwolf.dev> wrote this file.  As long as you retain this notice you
+ * can do whatever you want with this stuff. If we meet some day, and you think
+ * this stuff is worth it, you can buy me a beer in return.
+ * 
+ * - Jacob Wolf
+ * ----------------------------------------------------------------------------
+ */

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# biome-unnecessary-effect
+# Biome - React - Unnecessary Effect
+This is a plugin for [Biome](https://biomejs.dev/), the JavaScript and TypeScript linter, that identifies bad uses of the `useEffect` hook in React. 
+
+This plugin is heavily inspired and the code in it draws on rules in [@NickvanDyke](https://github.com/NickvanDyke)'s [eslint-plugin-react-you-might-not-need-an-effect](https://github.com/NickvanDyke/eslint-plugin-react-you-might-not-need-an-effect) package, which provides a similar functionality for ESLint. 
+
+>[!WARNING] 
+> This plugin is currently a work in progress. While it has been tested to work with the rudimentary examples found in the tests directory, you may find false positives. Please open a GitHub issue if you encounter one.
+
+## Installation
+
+You can add this plugin to your project using your preferred package manager:
+
+```bash
+npm install --save-dev @jacobwolf/biome-unnecessary-effect
+# or
+pnpm add -D @jacobwolf/biome-unnecessary-effect
+# or
+bun add -D biome-unnecessary-effect
+# or
+yarn add -D biome-unnecessary-effect
+```
+
+## Usage
+
+To use this plugin, you must have Biome 2.0+ installed. You can do so and configure Biome according to [their documentation](https://biomejs.dev/guides/getting-started). Plugins are not supported in Biome versions prior to 2.0.
+
+After installation, the plugin will automatically configure your `biome.json` file, adding the respective plugin rule. No manual setup is required!
+
+Then, you can run Biome:
+
+```bash
+npx biome lint --write
+# or
+bunx biome lint --write
+```
+
+## Rules
+
+This plugin currently includes the following rules:
+
+*   **avoidEmptyEffect**: Identifies and flags empty `useEffect` or `useLayoutEffect` hooks.
+
+*   **avoidInitializingState**: Flags `useEffect` or `useLayoutEffect` hooks that are used solely for initializing state. This should ideally be done directly with `useState`.
+
+*   **avoidDerivedOrChainedState**: Warns against storing derived state or chaining state updates within `useEffect` or `useLayoutEffect`. Consider computing derived values during render or combining state updates into a single event handler.
+
+*   **avoidDataFetchingInEffect**: Warns against directly fetching data inside `useEffect` or `useLayoutEffect`. Recommends using data fetching libraries like React Query (TanStack Query) or SWR for better handling of loading, caching, and errors.
+
+*   **avoidParentChildCoupling**: Warns against coupling parent behavior or state to a child component via `useEffect` or `useLayoutEffect`. Suggests lifting shared logic or state up to the parent component.
+
+*   **avoidEventHandler**: Flags `useEffect` or `useLayoutEffect` hooks that behave like event handlers. Instead, the event handler should be called directly.
+
+## Contributing
+
+Contributions are welcome! Please feel free to open issues or submit pull requests.
+
+## License
+
+This project is licensed under the Beerware License. See the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -1,13 +1,24 @@
 {
-  "name": "biome-unnecessary-effect",
-  "private": true,
+  "name": "@jacobwolf/biome-unnecessary-effect",
+  "version": "0.1.0",
+  "private": false,
   "scripts": {
     "test": "bun test",
     "format": "biome format",
     "format:fix": "biome format --write",
     "lint": "biome lint",
-    "lint:fix": "biome lint --write"
+    "lint:fix": "biome lint --write",
+    "build:plugin": "sh scripts/build.sh",
+    "prepublishOnly": "bun run build:plugin",
+    "postinstall": "node scripts/postinstall.js"
   },
+  "files": [
+    "grit",
+    "scripts/postinstall.js",
+    "bin",
+    "LICENSE",
+    "README.md"
+  ],
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
     "@types/bun": "1.2.18",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+SOURCE="scripts/setup_plugin.go"
+
+OUTPUT_DIR="bin"
+
+mkdir -p $OUTPUT_DIR
+
+echo "Building plugin binaries..."
+
+# macOS
+GOOS=darwin GOARCH=amd64 go build -o $OUTPUT_DIR/setup-darwin-amd64 $SOURCE
+GOOS=darwin GOARCH=arm64 go build -o $OUTPUT_DIR/setup-darwin-arm64 $SOURCE
+
+# Linux
+GOOS=linux GOARCH=amd64 go build -o $OUTPUT_DIR/setup-linux-amd64 $SOURCE
+GOOS=linux GOARCH=arm64 go build -o $OUTPUT_DIR/setup-linux-arm64 $SOURCE
+
+# Windows
+GOOS=windows GOARCH=amd64 go build -o $OUTPUT_DIR/setup-windows-amd64.exe $SOURCE
+GOOS=windows GOARCH=arm64 go build -o $OUTPUT_DIR/setup-windows-arm64.exe $SOURCE
+
+echo "Build complete. Binaries are in the '$OUTPUT_DIR' directory."

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,54 @@
+const { execFile } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const platform = process.platform;
+const arch = process.arch;
+
+let binaryName;
+
+const platformArchMapping = {
+  'darwin-x64': 'setup-darwin-amd64',
+  'darwin-arm64': 'setup-darwin-arm64',
+  'linux-x64': 'setup-linux-amd64',
+  'linux-arm64': 'setup-linux-arm64',
+  'win32-x64': 'setup-windows-amd64.exe',
+  'win32-arm64': 'setup-windows-arm64.exe',
+};
+
+const lookup = `${platform}-${arch}`;
+binaryName = platformArchMapping[lookup];
+
+if (!binaryName) {
+  console.error(`Unsupported platform: ${lookup}`);
+  console.error(
+    'Please open an issue on the biome-unnecessary-effect GitHub repository to request support for your platform.',
+  );
+  process.exit(1);
+}
+
+const binaryPath = path.join(__dirname, '..', 'bin', binaryName);
+
+if (!fs.existsSync(binaryPath)) {
+  console.error(`Cannot find plugin binary for your platform: ${binaryPath}`);
+  console.error('This is an issue with the package, not your machine.');
+  console.error('Please open an issue on the biome-unnecessary-effect GitHub repository.');
+  process.exit(1);
+}
+
+const child = execFile(binaryPath, (error, stdout, stderr) => {
+  if (error) {
+    console.error(`Error executing plugin setup: ${error}`);
+    if (stderr) console.error(stderr);
+    return;
+  }
+  if (stdout) console.log(stdout);
+  if (stderr) console.error(stderr);
+});
+
+child.on('close', (code) => {
+  if (code !== 0) {
+    console.error(`Plugin setup exited with code ${code}`);
+    process.exit(code);
+  }
+});

--- a/scripts/setup_plugin.go
+++ b/scripts/setup_plugin.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	pluginName          = "@jacobwolf/biome-unnecessary-effect"
+	requiredBiomeVersion = "2.0.0"
+	pluginPath          = "node_modules/@jacobwolf/biome-unnecessary-effect/grit/react-effects.grit"
+)
+
+type PackageJSON struct {
+	DevDependencies map[string]string `json:"devDependencies"`
+}
+
+type BiomeJSON struct {
+	Schema  string   `json:"$schema"`
+	Plugins []string `json:"plugins"`
+}
+
+func compareVersions(v1, v2 string) int {
+	parts1 := strings.Split(v1, ".")
+	parts2 := strings.Split(v2, ".")
+
+	maxLen := len(parts1)
+	if len(parts2) > maxLen {
+		maxLen = len(parts2)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		p1 := 0
+		if i < len(parts1) {
+			p1, _ = strconv.Atoi(parts1[i])
+		}
+		p2 := 0
+		if i < len(parts2) {
+			p2, _ = strconv.Atoi(parts2[i])
+		}
+
+		if p1 > p2 {
+			return 1
+		}
+		if p1 < p2 {
+			return -1
+		}
+	}
+	return 0
+}
+
+func main() {
+	if err := setupBiomePlugin(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("\n✨ Biome plugin setup complete!")
+}
+
+func setupBiomePlugin() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	packageJSONPath := filepath.Join(cwd, "package.json")
+	biomeJSONPath := filepath.Join(cwd, "biome.json")
+
+	fmt.Println("Checking Biome version...")
+	packageJSONContent, err := ioutil.ReadFile(packageJSONPath)
+	if err != nil {
+		return fmt.Errorf("failed to read package.json at %s: %w", packageJSONPath, err)
+	}
+
+	var pkg PackageJSON
+	if err := json.Unmarshal(packageJSONContent, &pkg); err != nil {
+		return fmt.Errorf("failed to parse package.json: %w", err)
+	}
+
+	biomeVersion, ok := pkg.DevDependencies["@biomejs/biome"]
+	if !ok {
+		return fmt.Errorf("@biomejs/biome not found in devDependencies. Please install it (e.g., `npm install -D @biomejs/biome`).")
+	}
+
+	cleanBiomeVersion := strings.TrimPrefix(strings.TrimPrefix(biomeVersion, "^"), "~")
+
+	if compareVersions(cleanBiomeVersion, requiredBiomeVersion) < 0 {
+		return fmt.Errorf("@biomejs/biome version %s is less than the required %s. Please upgrade.", biomeVersion, requiredBiomeVersion)
+	}
+	fmt.Printf("✅ @biomejs/biome version %s meets the requirement (%s or greater).\n", biomeVersion, requiredBiomeVersion)
+
+	fmt.Println("Configuring biome.json...")
+	
+	biomeJSONContent, err := ioutil.ReadFile(biomeJSONPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("biome.json not found at %s. The plugin cannot be added without an existing biome.json file. Please create it manually if you wish to add the plugin.", biomeJSONPath)
+		}
+		return fmt.Errorf("failed to read biome.json at %s: %w", biomeJSONPath, err)
+	}
+
+    var currentConfig map[string]interface{}
+    if err := json.Unmarshal(biomeJSONContent, &currentConfig); err != nil {
+        return fmt.Errorf("failed to parse biome.json: %w", err)
+    }
+
+    if _, ok := currentConfig["plugins"]; !ok {
+        currentConfig["plugins"] = []interface{}{}
+    }
+    pluginsList, ok := currentConfig["plugins"].([]interface{})
+    if !ok {
+        return fmt.Errorf("plugins field in biome.json is not a list")
+    }
+
+    found := false
+    for _, p := range pluginsList {
+        if str, ok := p.(string); ok && str == pluginPath {
+            found = true
+            break
+        }
+    }
+
+    if !found {
+        pluginsList = append(pluginsList, pluginPath)
+        currentConfig["plugins"] = pluginsList
+        
+        updatedBiomeJSON, err := json.MarshalIndent(currentConfig, "", "  ")
+        if err != nil {
+            return fmt.Errorf("failed to marshal biome.json: %w", err)
+        }
+        if err := ioutil.WriteFile(biomeJSONPath, updatedBiomeJSON, 0644); err != nil {
+            return fmt.Errorf("failed to write updated biome.json: %w", err)
+        }
+        fmt.Printf("✅ Added %s to biome.json\n", pluginPath)
+    } else {
+        fmt.Printf("ℹ️ %s is already present in biome.json. No changes made.\n", pluginPath)
+    }
+
+	return nil
+}


### PR DESCRIPTION
## Description
Adds the relevent build workflow to build binaries for MacOS, Linux, and Windows using Go. The binaries will check for a proper Biome version (>2.0.0) and then add the Grit file as a plugin if not present as a rule. 

In addition to the workflow and the binary builder, we've updated the README and LICENSE to include the appropriate install info. We've chosen the Beerware license for open-source contribution and use.