### PR TITLE
fix(binaries): updates postinstall script to use proper working directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "binaries"
+    ]
+}

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const platform = process.platform;
 const arch = process.arch;
 
-let binaryName;
+let binaryName = null;
 
 const platformArchMapping = {
   'darwin-x64': 'setup-darwin-amd64',
@@ -36,7 +36,9 @@ if (!fs.existsSync(binaryPath)) {
   process.exit(1);
 }
 
-const child = execFile(binaryPath, (error, stdout, stderr) => {
+const projectRoot = process.env.INIT_CWD || process.env.npm_config_local_prefix || process.cwd();
+
+const child = execFile(binaryPath, { cwd: projectRoot }, (error, stdout, stderr) => {
   if (error) {
     console.error(`Error executing plugin setup: ${error}`);
     if (stderr) console.error(stderr);


### PR DESCRIPTION
## Description
Solves #7 by using the proper `projectRoot` rather than attempting to find the correct `biome.json` inside of the working directory, rather than attempting to find it in the `node_modules` directory when installed by users.