### PR TITLE
fix(rules): removes cleanup false positive, tests suppressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "conventionalCommits.scopes": [
-        "binaries"
+        "binaries",
+        "rules"
     ]
 }

--- a/grit/react-effects.grit
+++ b/grit/react-effects.grit
@@ -232,6 +232,7 @@ any {
     $body <: contains `if ($condition) { $ifBody }`,
     $condition <: not contains `!ignore`,
     $condition <: not contains `error`,
+    $body <: not contains `return $cleanup`,
     $body <: not contains `return () =>`,
     $body <: not contains `return function`,
     register_diagnostic(span=$effect, message="Avoid using state as an event handler. Instead, call the event handler directly.")
@@ -241,6 +242,7 @@ any {
     $body <: contains `if ($condition) { $ifBody }`,
     $condition <: not contains `!ignore`,
     $condition <: not contains `error`,
+    $body <: not contains `return $cleanup`,
     $body <: not contains `return () =>`,
     $body <: not contains `return function`,
     register_diagnostic(span=$effect, message="Avoid using state as an event handler. Instead, call the event handler directly.")

--- a/tests/fixtures/suppression.tsx
+++ b/tests/fixtures/suppression.tsx
@@ -1,0 +1,8 @@
+import { useEffect } from 'react';
+
+export function EmptyEffectComponent() {
+  // biome-ignore lint: This comment should suppress the empty effect warning
+  useEffect(() => {}, []);
+
+  return <div>Empty Effect</div>;
+}

--- a/tests/fixtures/valid-editor-transform-effect.tsx
+++ b/tests/fixtures/valid-editor-transform-effect.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+declare const ParagraphNode: unknown;
+
+type Editor = {
+  registerNodeTransform: (
+    node: unknown,
+    callback: (node: { getTextContent: () => string; remove: () => void }) => void,
+  ) => () => void;
+};
+
+declare function useEditor(): Editor;
+
+export function ValidEditorTransformEffect() {
+  const editor = useEditor();
+
+  useEffect(() => {
+    return editor.registerNodeTransform(ParagraphNode, (node) => {
+      if (node.getTextContent().trim() === '') {
+        node.remove();
+      }
+    });
+  }, [editor]);
+
+  return null;
+}

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -79,4 +79,14 @@ describe('unnecessary-effect plugin', () => {
     const { exitCode } = runBiome(resolve(FIXTURES_PATH, 'valid-effect.tsx'));
     expect(exitCode).toBe(0);
   });
+
+  test('should not report registering editor transforms', () => {
+    const { exitCode } = runBiome(resolve(FIXTURES_PATH, 'valid-editor-transform-effect.tsx'));
+    expect(exitCode).toBe(0);
+  });
+
+  test('should respect suppression comments', () => {
+    const { exitCode } = runBiome(resolve(FIXTURES_PATH, 'suppression.tsx'));
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Description
Solves #6 by fixing false positives where the `avoidEventHandler` rule was flagging valid cleanup functions.

This PR also adds a test to test the `biome-ignore lint` suppressions and ensure that they work.